### PR TITLE
Fix browsers freezing on re-calculating styles

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useLayoutEffect } from 'react';
 import './utilities.css';
 import './common.css';
 import Specs from './components/specs/specs';
@@ -87,14 +87,23 @@ function App() {
     greySaturation,
   })
 
-  const style = document.createElement('style')
-  document.head.appendChild(style)
-  style.innerHTML = `
-    :root{
-      ${Object.values(variables).join('')}
+  const styleRef = useRef()
+
+  useLayoutEffect(() => {
+    // Only create style element once
+    if (!styleRef.current) {
+      const style = document.createElement('style')
+      document.head.appendChild(style)
+      styleRef.current = style;
     }
-    ${darkModeStyles}
-  `
+
+    styleRef.current.innerHTML = `
+      :root{
+        ${Object.values(variables).join('')}
+      }
+      ${darkModeStyles}
+    `
+  }, [variables])
 
   const handleRandomize = () => {
     setFontFamily(getRandomObject().fontFamily)


### PR DESCRIPTION
Hi there :wave: 

I love this app and it's an excellent resource to demonstrate the power of CSS Custom Properties! This makes it really easy to grasp the strengths of them, even for non-developers :raised_hands: Thank you so much for creating it!

While playing around with it a while I noticed that my browser was freezing for a few seconds before applying the new styles. Initially [I thought it was a bug in their CSS engine](https://bugzilla.mozilla.org/show_bug.cgi?id=1651627), but the slowdown turns out to be caused by the page instead.

Before this PR each change lead to a new `<style>`-node being created and appended to the DOM. Old style nodes were never reused. The list quickly grows to a few hundred style nodes when dragging a few settings. Re-calculating hundreds of stylesheets is expensive and can lead to browsers freezing for a few seconds.

Therefore the fix is to always re-use the same style node and mark the DOM node creation as a layout effect for React to schedule accordingly. With this change the page is now snappy again for me, no matter how many settings I change. 